### PR TITLE
Fixed player start-up issue.

### DIFF
--- a/index.cehtml
+++ b/index.cehtml
@@ -1,3 +1,4 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <?xml version="1.0" encoding="UTF-8" ?>
 <!--
  *
@@ -31,7 +32,6 @@
 		type - type of player that shall be used,
 		 		possible values: AVObject player, html5 (only for HbbTV profile 2.0)
 -->
-<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml">
 <head>
 	<title>HbbPlayer</title>


### PR DESCRIPTION
DOCTYPE must be first line in document otherwise the player does not work correctly.
Tested on KantM 2017.

Signed-off-by: Peter Antoine <p.antoine@samsung.com>