### PR TITLE
Remove 'autoplay' tag

### DIFF
--- a/index.cehtml
+++ b/index.cehtml
@@ -82,9 +82,9 @@
 			source.type = "video/mp4";
 			player.appendChild(source);
 
-			player.autoplay = true;
-
 			document.body.appendChild(player);
+
+			player.play();
 		}
 
         window.onload = function() {


### PR DESCRIPTION
HTML5 doesn't support 'autoplay' tag in smarthub application so it should be replaced with manually asking video to play.